### PR TITLE
Create config files with the service user when using runit

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -7,6 +7,15 @@ end
 action :create do
   templates = new_resource.templates.map { |v| Mash.from_hash(v) }
 
+  case node['consul_template']['init_style']
+  when 'runit'
+    consul_template_user = node['consul_template']['service_user']
+    consul_template_group = node['consul_template']['service_group']
+  else
+    consul_template_user = 'root'
+    consul_template_group = 'root'
+  end
+
   # Create entries in configs-template dir but only if it's well formed
   templates.each_with_index do |v, i|
     fail "Missing source for #{i} entry at '#{new_resource.name}" if v[:source].nil?
@@ -16,6 +25,8 @@ action :create do
   template ::File.join(node['consul_template']['config_dir'], new_resource.name) do
     cookbook 'consul-template'
     source 'config-template.json.erb'
+    user consul_template_user
+    group consul_template_group
     mode node['consul_template']['template_mode']
     variables(:templates => templates)
     not_if { templates.empty? }


### PR DESCRIPTION
The cookbook currently always creates template configs files owned by root. However, if runit is running the service as another user, like consul-template, it's unable to read its own config files. This patch uses the `consul_template.service_group` and `consul_template.service_group` attributes to define ownership of the template configs.