### PR TITLE
Runit logging

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -98,6 +98,9 @@ when 'runit'
         command: command,
         options: options
     )
+    env({
+      'CONSUL_TEMPLATE_LOG' => node['consul_template']['log_level']
+    })
   end
 
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -98,9 +98,7 @@ when 'runit'
         command: command,
         options: options
     )
-    env({
-      'CONSUL_TEMPLATE_LOG' => node['consul_template']['log_level']
-    })
+    env 'CONSUL_TEMPLATE_LOG' => node['consul_template']['log_level']
   end
 
 end

--- a/templates/default/sv-consul-template-run.erb
+++ b/templates/default/sv-consul-template-run.erb
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 exec chpst -u '<%= node['consul_template']['service_user'] %>':'<%= node['consul_template']['service_group'] %>'  \
   <%= @options[:command] %>                                                                                  \
   <%= @options[:options] %>                                                                                  \

--- a/templates/default/sv-consul-template-run.erb
+++ b/templates/default/sv-consul-template-run.erb
@@ -1,6 +1,7 @@
 #!/bin/sh
 exec 2>&1
 exec chpst -u '<%= node['consul_template']['service_user'] %>':'<%= node['consul_template']['service_group'] %>'  \
+  -e <%= node['runit']['service_dir'] %>/consul-template/env                                                 \
   <%= @options[:command] %>                                                                                  \
   <%= @options[:options] %>                                                                                  \
 #                                                                                                             #


### PR DESCRIPTION
A couple of changes here:

- Redirect stderr to stdout in the consul-template runner so that the runit logger gets the log data.
- Allow the `consul_template.log_level` attribute to control the log level used by consul when managed by runit.