### PR TITLE
Notify restart runit_service if such is the init_style

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -61,7 +61,11 @@ file File.join(node['consul_template']['config_dir'], 'default.json') do
   mode node['consul_template']['template_mode']
   action :create
   content JSON.pretty_generate(node['consul_template']['config'], quirks_mode: true)
-  notifies :restart, 'service[consul-template]', :delayed
+  if node['consul_template']['init_style'] == 'runit'
+    notifies :restart, 'runit_service[consul-template]', :delayed
+  else
+    notifies :restart, 'service[consul-template]', :delayed
+  end
 end
 
 command = "#{node['consul_template']['install_dir']}/consul-template"


### PR DESCRIPTION
### Previous behavior
Notifying restart of `service[consul-template]` ([here](https://github.com/adamkrone/chef-consul-template/blob/master/recipes/service.rb#L64)) when running `docker build` always resulted for me in the following error: `warning: /etc/service/consul-template: unable to open supervise/ok: file does not exist`.

Also it is inconsistent with the further part of the [service recipe](https://github.com/adamkrone/chef-consul-template/blob/master/recipes/service.rb#L98).

### Changes
I corrected that notification to restart `runit_service[consul-template]` if runit is the init_style. 