### PR TITLE
do not use quotes on perms in template config

### DIFF
--- a/templates/default/config-template.json.erb
+++ b/templates/default/config-template.json.erb
@@ -6,7 +6,7 @@ template {
   command = "<%= template[:command] %>"
   <% end %>
   <% unless template[:perms].nil? %>
-  perms = "<%= template[:perms] %>"
+  perms = <%= template[:perms] %>
   <% end %>
 }
 <% end  %>


### PR DESCRIPTION
Removes quotes on perms field in template configuration. Without this, consul-template fails to start correctly and gives this error:

`'template[0].perms' expected type 'os.FileMode', got unconvertible type 'string'`