### PR TITLE
Support service_user and service_group on upstart

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@ default['consul_template']['source_revision'] = 'master'
 # Service attributes
 default['consul_template']['log_level'] = 'info'
 default['consul_template']['config_dir'] = '/etc/consul-template.d'
-default['consul_template']['init_style'] = 'init' # 'init', 'runit', 'systemd', 'upstart'
+default['consul_template']['init_style'] = platform?("ubuntu") ? 'upstart' : 'init' # 'init', 'runit', 'systemd', 'upstart'
 default['consul_template']['service_user'] = 'consul-template'
 default['consul_template']['service_group'] = 'consul-template'
 default['consul_template']['template_mode'] = 0600

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -8,7 +8,7 @@ action :create do
   templates = new_resource.templates.map { |v| Mash.from_hash(v) }
 
   case node['consul_template']['init_style']
-  when 'runit', 'systemd'
+  when 'runit', 'systemd', 'upstart'
     consul_template_user = node['consul_template']['service_user']
     consul_template_group = node['consul_template']['service_group']
   else

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -21,7 +21,7 @@ when 'runit'
   consul_template_user = node['consul_template']['service_user']
   consul_template_group = node['consul_template']['service_group']
   consul_template_directories << '/var/log/consul-template'
-when 'systemd'
+when 'systemd', 'upstart'
   consul_template_user = node['consul_template']['service_user']
   consul_template_group = node['consul_template']['service_group']
 else
@@ -73,8 +73,7 @@ options = "-config #{node['consul_template']['config_dir']}"
 
 case node['consul_template']['init_style']
 when 'init', 'upstart'
-  is_upstart = node['consul_template']['init_style'] == 'upstart'
-  if platform?("ubuntu") || is_upstart
+  if node['consul_template']['init_style'] == 'upstart'
     is_upstart = true
     init_file = '/etc/init/consul-template.conf'
     init_tmpl = 'consul-template-conf.erb'
@@ -89,7 +88,9 @@ when 'init', 'upstart'
     variables(
       command: command,
       options: options,
-      loglevel: node['consul_template']['log_level']
+      loglevel: node['consul_template']['log_level'],
+      service_user: consul_template_user,
+      service_group: consul_template_group
     )
     notifies :restart, 'service[consul-template]', :immediately
   end

--- a/spec/recipes/service_spec.rb
+++ b/spec/recipes/service_spec.rb
@@ -44,12 +44,12 @@ describe 'consul-template::service' do
       expect(chef_run).to create_template('/etc/init/consul-template.conf')
     end
 
-    it 'should not create the consul-template service user (using root)' do
-      expect(chef_run).to_not create_user('root')
+    it 'should create the consul-template service user' do
+      expect(chef_run).to create_user('consul-template')
     end
 
-    it 'should not create the consul-template service group (using root)' do
-      expect(chef_run).to_not create_group('root')
+    it 'should create the consul-template service group' do
+      expect(chef_run).to create_group('consul-template')
     end
   end
 

--- a/templates/default/consul-template-conf.erb
+++ b/templates/default/consul-template-conf.erb
@@ -3,10 +3,15 @@ description "Consul Template Service (Upstart)"
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [06]
 
+kill timeout 20
+
+setuid <%= @service_user %>
+setgid <%= @service_group %>
+
 env CONSUL_TEMPLATE_LOG=info
 env GOMAXPROCS=${GOMAXPROCS}
 
-exec <%= @command %> <%= @options %> >> /var/log/consul-template.log 2>&1
+exec <%= @command %> <%= @options %>
 
 respawn
 respawn limit 10 10


### PR DESCRIPTION
Currently when using the upstart init_style consul-template runs as root. This PR uses the setuid and setgid features of upstart to run consul-template as a service user 

It also adds a 20 second kill timeout as consul-template can take up to 15 seconds to shutdown when running in de-duplicate mode