### PR TITLE
Drop "supports :reload" from runit_service definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ IMPROVEMENTS:
 - Updates default version of consul-template to 0.13.0, adds new checksums
   ([GH-47](https://github.com/adamkrone/chef-consul-template/pull/47))
 
+BUG FIXES:
+
+- Drop "supports :reload" from runit_service definition since the
+  runit cookbook does not define a reload_command for runit_service
+  resources
+
 ## v0.10.0 (February 25th, 2016)
 
 IMPROVEMENTS:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'krone.adam@gmail.com'
 license          'Apache v2.0'
 description      'Installs/Configures consul-template'
 long_description 'Installs/Configures consul-template'
-version          '0.10.0'
+version          '0.10.1'
 
 recipe 'consul-template', 'Installs, configures, and starts the consul-template service.'
 recipe 'consul-template::install_binary', 'Installs consul-template from binary.'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'krone.adam@gmail.com'
 license          'Apache v2.0'
 description      'Installs/Configures consul-template'
 long_description 'Installs/Configures consul-template'
-version          '0.10.1'
+version          '0.10.0'
 
 recipe 'consul-template', 'Installs, configures, and starts the consul-template service.'
 recipe 'consul-template::install_binary', 'Installs consul-template from binary.'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -104,7 +104,7 @@ when 'init', 'upstart'
 
 when 'runit'
   runit_service 'consul-template' do
-    supports status: true, restart: true, reload: true
+    supports status: true, restart: true
     action [:enable, :start]
     log true
     options(


### PR DESCRIPTION
Drop "supports :reload" from runit_service definition since the runit cookbook does not define a reload_command for runit_service resources.

Otherwise chef runs fail with:
```Generated at 2016-05-26 23:37:59 +0000
Chef::Exceptions::UnsupportedAction: service[consul-template] (dynamically defined) had an error: Chef::Exceptions::UnsupportedAction: #<Chef::Provider::Service::Simple:0x0000000a4972d0> requires a reload_command be set in order to perform a reload
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/mixin/why_run.rb:240:in `run'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/mixin/why_run.rb:321:in `block in run'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/mixin/why_run.rb:320:in `each'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/mixin/why_run.rb:320:in `run'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/provider.rb:155:in `process_resource_requirements'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/provider.rb:133:in `run_action'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/resource.rb:596:in `run_action'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/runner.rb:69:in `run_action'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/runner.rb:127:in `run_delayed_notification'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/runner.rb:115:in `block in run_delayed_notifications'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/runner.rb:114:in `each'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/runner.rb:114:in `run_delayed_notifications'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/runner.rb:104:in `converge'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/client.rb:667:in `block in converge'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/client.rb:662:in `catch'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/client.rb:662:in `converge'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/client.rb:701:in `converge_and_save'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/client.rb:281:in `run'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application.rb:285:in `block in fork_chef_client'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application.rb:273:in `fork'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application.rb:273:in `fork_chef_client'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application.rb:238:in `block in run_chef_client'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/local_mode.rb:44:in `with_server_connectivity'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application.rb:226:in `run_chef_client'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application/client.rb:456:in `sleep_then_run_chef_client'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application/client.rb:443:in `block in interval_run_chef_client'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application/client.rb:442:in `loop'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application/client.rb:442:in `interval_run_chef_client'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application/client.rb:426:in `run_application'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib/chef/application.rb:58:in `run'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/bin/chef-client:26:in `<top (required)>'
/usr/bin/chef-client:51:in `load'
/usr/bin/chef-client:51:in `<main>'
```