### PR TITLE
Add Windows operating system support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,7 +14,7 @@ platforms:
   - name: centos-7.2
   - name: windows-2012r2
     driver:
-      box: mwrock/windows2012r2
+      box: mwrock/Windows2012R2
       communicator: winrm
       shell_type: powershell
     provisioner:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,13 @@ platforms:
   - name: debian-7.9
   - name: centos-6.7
   - name: centos-7.2
+  - name: windows-2012r2
+    driver:
+      box: mwrock/windows2012r2
+      communicator: winrm
+      shell_type: powershell
+    provisioner:
+      require_chef_omnibus: true
 
 suites:
   - name: install_only
@@ -19,6 +26,7 @@ suites:
       - recipe[apt::default]
       - recipe[consul::default]
       - recipe[consul-template::install_binary]
+    excludes: ['windows-2012r2']
     attributes:
       apt:
         compile_time_update: true
@@ -32,7 +40,7 @@ suites:
       - recipe[consul::default]
       - recipe[consul-template::default]
       - recipe[consul-template-spec::consul_template_config]
-    excludes: ['debian-8.2', 'centos-7.2']
+    excludes: ['debian-8.2', 'centos-7.2', 'windows-2012r2']
     attributes:
       apt:
         compile_time_update: true
@@ -49,6 +57,7 @@ suites:
       - recipe[consul::default]
       - recipe[consul-template::default]
       - recipe[consul-template-spec::consul_template_config]
+    excludes: ['windows-2012r2']
     attributes:
       apt:
         compile_time_update: true
@@ -66,6 +75,7 @@ suites:
       - recipe[consul::default]
       - recipe[consul-template::default]
       - recipe[consul-template-spec::consul_template_config]
+    excludes: ['windows-2012r2']
     attributes:
       apt:
         compile_time_update: true
@@ -91,5 +101,19 @@ suites:
           server: true
       consul_template:
         init_style: 'systemd'
+        config:
+          consul: '127.0.0.1:8500'
+  - name: windows
+    run_list:
+      - recipe[consul::default]
+      - recipe[consul-template::default]
+      - recipe[consul-template-spec::consul_template_config_win]
+    includes: ['windows-2012r2']
+    attributes:
+      consul:
+        config:
+          bootstrap_expect: 1
+          server: true
+      consul_template:
         config:
           consul: '127.0.0.1:8500'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,3 +27,13 @@ default['consul_template']['template_mode'] = 0600
 
 # Config attributes
 default['consul_template']['config'] = Hash.new
+
+# Windows only
+default['consul_template']['nssm_params'] = {
+  'AppDirectory'     => data_path,
+  'AppStdout'        => join_path(config_prefix_path, 'stdout.log'),
+  'AppStderr'        => join_path(config_prefix_path, 'error.log'),
+  'AppRotateFiles'   => 1,
+  'AppRotateOnline'  => 1,
+  'AppRotateBytes'   => 20_000_000
+}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,13 +5,21 @@
 default['consul_template']['base_url'] = 'https://releases.hashicorp.com/consul-template/'
 default['consul_template']['version'] = '0.15.0'
 default['consul_template']['install_method'] = 'binary'
-default['consul_template']['install_dir'] = '/usr/local/bin'
+default['consul_template']['install_dir'] = if node['platform'] == 'windows'
+                                              "#{ENV['SystemDrive']}/Program Files/consul_template"
+                                            else
+                                              '/usr/local/bin'
+                                            end
 
 default['consul_template']['source_revision'] = 'master'
 
 # Service attributes
 default['consul_template']['log_level'] = 'info'
-default['consul_template']['config_dir'] = '/etc/consul-template.d'
+default['consul_template']['config_dir'] = if node['platform'] == 'windows'
+                                             "#{ENV['SystemDrive']}/Program Files/consul_template/consul_template.d"
+                                           else
+                                             '/etc/consul-template.d'
+                                           end
 default['consul_template']['init_style'] = platform?("ubuntu") ? 'upstart' : 'init' # 'init', 'runit', 'systemd', 'upstart'
 default['consul_template']['service_user'] = 'consul-template'
 default['consul_template']['service_group'] = 'consul-template'

--- a/libraries/consul-template_helpers.rb
+++ b/libraries/consul-template_helpers.rb
@@ -24,5 +24,32 @@ class Chef::Recipe::ConsulTemplateHelpers
     def install_arch(machine_arch)
       machine_arch =~ /x86_64/ ? 'amd64' : '386'
     end
+
+    # returns windows friendly version of the provided path,
+    # ensures backslashes are used everywhere
+    # Gently plucked from https://github.com/chef-cookbooks/windows
+    def win_friendly_path(path)
+      path.gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR || '\\') if path
+    end
+
+    # Simply using ::File.join was causing several attributes
+    # to return strange values in the resources
+    # (e.g. "C:/Program Files/\\consul\\data")
+    def join_path(*path)
+      win_friendly_path(::File.join(path))
+    end
+
+    def program_files
+      join_path('C:', 'Program Files') +
+        (node['kernel']['machine'] =~ /x86_64/ ? '' : ' x(86)')
+    end
+
+    def config_prefix_path
+      join_path(program_files, 'consul')
+    end
+
+    def data_path
+      join_path(program_files, 'consul', 'data')
+    end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,6 +20,7 @@ depends 'ark'
 depends 'libarchive'
 depends 'golang', '~> 1.4'
 depends 'runit'
+depends 'nssm', '~> 1.2'
 
 issues_url 'https://github.com/adamkrone/chef-consul-template/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/adamkrone/chef-consul-template' if respond_to?(:source_url)

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -24,21 +24,32 @@ action :create do
 
   # Ensure config directory exists
   directory node['consul_template']['config_dir'] do
-    user consul_template_user
-    group consul_template_group
-    mode 0o755
+    unless node['platform'] == 'windows'
+      user consul_template_user
+      group consul_template_group
+      mode 0o755
+    end
     recursive true
     action :create
   end
 
-  template ::File.join(node['consul_template']['config_dir'], new_resource.name) do
-    cookbook 'consul-template'
-    source 'config-template.json.erb'
-    user consul_template_user
-    group consul_template_group
-    mode node['consul_template']['template_mode']
-    variables(:templates => templates)
-    not_if { templates.empty? }
+  if node['platform'] == 'windows'
+    template ::File.join(node['consul_template']['config_dir'], new_resource.name) do
+      cookbook 'consul-template'
+      source 'config-template-win.json.erb'
+      variables(:templates => templates)
+      not_if { templates.empty? }
+    end
+  else
+    template ::File.join(node['consul_template']['config_dir'], new_resource.name) do
+      cookbook 'consul-template'
+      source 'config-template.json.erb'
+      user consul_template_user
+      group consul_template_group
+      mode node['consul_template']['template_mode']
+      variables(:templates => templates)
+      not_if { templates.empty? }
+    end
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,5 +7,10 @@
 #
 #
 
-include_recipe "consul-template::install_#{node['consul_template']['install_method']}"
-include_recipe "consul-template::service"
+if node['platform'] == 'windows'
+  include_recipe "consul-template::install_windows_#{node['consul_template']['install_method']}"
+  include_recipe "consul-template::service_windows"
+else
+  include_recipe "consul-template::install_#{node['consul_template']['install_method']}"
+  include_recipe "consul-template::service"
+end

--- a/recipes/install_windows_binary.rb
+++ b/recipes/install_windows_binary.rb
@@ -1,0 +1,41 @@
+#
+# Cookbook Name:: consul-template
+# Recipe:: install_windows_binary
+#
+# Copyright (C) 2016
+#
+#
+#
+
+require 'chef/version_constraint'
+
+url = ::URI.join(node['consul_template']['base_url'],
+                 "#{node['consul_template']['version']}/",
+                 ConsulTemplateHelpers.install_file(node)).to_s
+
+download_path = "#{Chef::Config['file_cache_path']}\
+/#{ConsulTemplateHelpers.install_file(node)}".tr('/', '\\')
+install_path = "#{node['consul_template']['install_dir']}\
+/#{ConsulTemplateHelpers.install_version(node)}".tr('/', '\\')
+
+remote_file download_path do
+  source url
+  checksum ConsulTemplateHelpers.install_checksum(node)
+  action :create_if_missing
+end
+
+directory install_path do
+  recursive true
+  action :create
+end
+
+powershell_script 'Unzip consul_template' do
+  code <<-EOH
+  $shell = new-object -com shell.application
+  $zip = $shell.NameSpace('#{download_path}')
+  foreach($item in $zip.items()) {
+    $shell.Namespace('#{install_path}').copyhere($item)
+  }
+  EOH
+  not_if { ::File.exist?("#{install_path}\\consul-template.exe") }
+end

--- a/recipes/install_windows_source.rb
+++ b/recipes/install_windows_source.rb
@@ -1,0 +1,10 @@
+#
+# Cookbook Name:: consul-template
+# Recipe:: install_windows_source
+#
+# Copyright (C) 2016
+#
+#
+#
+
+raise 'Installation from source code is not yet supported for Windows operating system. Use binary instead.'

--- a/recipes/service_windows.rb
+++ b/recipes/service_windows.rb
@@ -32,6 +32,7 @@ command = "#{node['consul_template']['install_dir']}\
 nssm service_name do
   program command
   args %(-config="""#{node['consul_template']['config_dir']}""")
+  params node['consul_template']['nssm_params']
   action :install
 end
 

--- a/recipes/service_windows.rb
+++ b/recipes/service_windows.rb
@@ -1,0 +1,41 @@
+#
+# Cookbook Name:: consul-template
+# Recipe:: service_windows
+#
+# Copyright (C) 2016
+#
+#
+#
+
+require 'json'
+
+# Configure directories
+consul_template_directories = []
+consul_template_directories << node['consul_template']['config_dir']
+
+# Create service directories
+consul_template_directories.each do |dirname|
+  directory dirname
+end
+
+service_name = 'consul_template'
+# Define global options here. use consul_template lwrp to register new
+# templates
+file File.join(node['consul_template']['config_dir'], 'default.json') do
+  action :create
+  content JSON.pretty_generate(node['consul_template']['config'], quirks_mode: true)
+  notifies :restart, "service[#{service_name}]", :delayed
+end
+
+command = "#{node['consul_template']['install_dir']}\
+/#{ConsulTemplateHelpers.install_version(node)}/consul-template.exe".tr('/', '\\')
+nssm service_name do
+  program command
+  args %(-config="""#{node['consul_template']['config_dir']}""")
+  action :install
+end
+
+service service_name do
+  supports status: true, restart: true, start: true
+  action [:enable, :start]
+end

--- a/spec/fixtures/cookbooks/consul-template-spec/recipes/consul_template_config_win.rb
+++ b/spec/fixtures/cookbooks/consul-template-spec/recipes/consul_template_config_win.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: consul-template-spec
+# Recipe:: consul_template_config_win
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+include_recipe 'consul-template::default'
+
+template "#{ENV['SystemDrive']}\\test.config.ctmpl" do
+  source 'test.config.ctmpl.erb'
+end
+
+consul_template_config 'test' do
+  templates [{
+    source: 'C:\\test.config.ctmpl',
+    destination: 'C:\\test.config',
+    command: 'echo %errorlevel% > C:/consul-template-command-test'
+  }]
+  notifies :restart, 'service[consul_template]'
+end
+
+powershell_script 'add test key/value' do
+  code "Invoke-RestMethod -Method PUT -Body 'something' -Uri http://localhost:8500/v1/kv/test"
+end

--- a/templates/default/config-template-win.json.erb
+++ b/templates/default/config-template-win.json.erb
@@ -1,0 +1,15 @@
+<% @templates.each do |template| -%>
+template {
+  source = "<%= template[:source].tr('\\', '/') %>"
+  destination = "<%= template[:destination].tr('\\', '/') %>"
+  <% unless template[:command].nil? %>
+  command = "<%= template[:command].tr('\\', '/') %>"
+  <% end %>
+  <% unless template[:perms].nil? %>
+  perms = <%= template[:perms] %>
+  <% end %>
+  <% unless template[:wait].nil? %>
+  wait = "<%= template[:wait] %>"
+  <% end %>
+}
+<% end  %>

--- a/test/integration/windows/serverspec/windows_spec.rb
+++ b/test/integration/windows/serverspec/windows_spec.rb
@@ -1,0 +1,42 @@
+require 'serverspec'
+
+set :backend, :cmd
+set :os, family: 'windows'
+
+describe 'Сonsul template service' do
+  it 'has an executable file' do
+    expect(file(
+             'C:\\Program Files\\consul_template\\consul-template_0.15.0_windows_amd64\\consul-template.exe'
+    )).to exist
+  end
+
+  it 'has a configuration file' do
+    expect(file('C:\\Program Files\\consul_template\\consul_template.d\\default.json')).to be_file
+  end
+
+  it 'is running as a service' do
+    expect(service('consul_template')).to be_running
+  end
+
+  it 'is enabled as a service' do
+    expect(service('consul_template')).to have_start_mode('Automatic')
+  end
+end
+
+describe 'consul_template_config LWRP' do
+  it 'has a configuration file' do
+    expect(file(
+             'C:\\Program Files\\consul_template\\consul_template.d\\test'
+    )).to be_file
+    expect(file(
+             'C:\\Program Files\\consul_template\\consul_template.d\\test'
+    )).to contain 'source = "C:/test.config.ctmpl"'
+    expect(file(
+             'C:\\Program Files\\consul_template\\consul_template.d\\test'
+    )).to contain 'destination = "C:/test.config"'
+  end
+
+  it 'executed trigger command' do
+    expect(file('C:\\consul-template-command-test')).to be_file
+  end
+end


### PR DESCRIPTION
Because consul application and consul cookbook have support for Windows it is better to have this support in this cookbook also. These changes should not affect other platforms at all.
Tested on Windows Server 2012 R2 box on Parallels Desktop 11.