### PR TITLE
Using poise_service instead of manual service creation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@ default['consul_template']['source_revision'] = 'master'
 # Service attributes
 default['consul_template']['log_level'] = 'info'
 default['consul_template']['config_dir'] = '/etc/consul-template.d'
-default['consul_template']['init_style'] = platform?("ubuntu") ? 'upstart' : 'init' # 'init', 'runit', 'systemd', 'upstart'
+default['consul_template']['init_style'] = 'init' # 'init', 'runit', 'systemd', 'upstart'
 default['consul_template']['service_user'] = 'consul-template'
 default['consul_template']['service_group'] = 'consul-template'
 default['consul_template']['template_mode'] = 0600

--- a/libraries/consul-template_helpers.rb
+++ b/libraries/consul-template_helpers.rb
@@ -16,8 +16,7 @@ class Chef::Recipe::ConsulTemplateHelpers
       ['consul-template',
        node['consul_template']['version'],
        node['os'],
-       install_arch(node['kernel']['machine'])
-      ].join('_')
+       install_arch(node['kernel']['machine'])].join('_')
     end
 
     private

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,6 +20,7 @@ depends 'ark'
 depends 'libarchive'
 depends 'golang', '~> 1.4'
 depends 'runit'
+depends 'poise-service'
 
 issues_url 'https://github.com/adamkrone/chef-consul-template/issues'
 source_url 'https://github.com/adamkrone/chef-consul-template'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -40,7 +40,7 @@ file File.join(node['consul_template']['config_dir'], 'default.json') do
   notifies :restart, 'poise_service[consul-template]', :delayed
 end
 
-# Create service
+# Create service using poise
 poise_service 'consul-template' do
   command "#{cmd} #{opt}"
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -13,42 +13,18 @@ require 'json'
 consul_template_directories = []
 consul_template_directories << node['consul_template']['config_dir']
 
-# Select service user & group
-case node['consul_template']['init_style']
-when 'runit'
-  include_recipe 'runit::default'
-
-  consul_template_user = node['consul_template']['service_user']
-  consul_template_group = node['consul_template']['service_group']
-  consul_template_directories << '/var/log/consul-template'
-when 'systemd', 'upstart'
-  consul_template_user = node['consul_template']['service_user']
-  consul_template_group = node['consul_template']['service_group']
-else
-  consul_template_user = 'root'
-  consul_template_group = 'root'
+# Defince service parameters
+poise_service_user node['consul_template']['service_user'] do
+  group node['consul_template']['service_group']
 end
-
-# Create service user
-user consul_template_user do
-  not_if { consul_template_user == 'root' }
-  home '/dev/null'
-  shell '/bin/false'
-  comment 'consul-template service user'
-end
-
-# Create service group
-group consul_template_group do
-  not_if { consul_template_group == 'root' }
-  members consul_template_user
-  append true
-end
+cmd = "#{node['consul_template']['install_dir']}/consul-template"
+opt = "-config #{node['consul_template']['config_dir']}"
 
 # Create service directories
 consul_template_directories.each do |dirname|
   directory dirname do
-    owner consul_template_user
-    group consul_template_group
+    owner node['consul_template']['service_user']
+    group node['consul_template']['service_group']
     mode 0755
   end
 end
@@ -56,80 +32,15 @@ end
 # Define global options here. use consul_template lwrp to register new
 # templates
 file File.join(node['consul_template']['config_dir'], 'default.json') do
-  user consul_template_user
-  group consul_template_group
+  user node['consul_template']['service_user']
+  group node['consul_template']['service_group']
   mode node['consul_template']['template_mode']
   action :create
   content JSON.pretty_generate(node['consul_template']['config'], quirks_mode: true)
-  if node['consul_template']['init_style'] == 'runit'
-    notifies :restart, 'runit_service[consul-template]', :delayed
-  else
-    notifies :restart, 'service[consul-template]', :delayed
-  end
+  notifies :restart, 'poise_service[consul-template]', :delayed
 end
 
-command = "#{node['consul_template']['install_dir']}/consul-template"
-options = "-config #{node['consul_template']['config_dir']}"
-
-case node['consul_template']['init_style']
-when 'init', 'upstart'
-  if node['consul_template']['init_style'] == 'upstart'
-    is_upstart = true
-    init_file = '/etc/init/consul-template.conf'
-    init_tmpl = 'consul-template-conf.erb'
-  else
-    init_file = '/etc/init.d/consul-template'
-    init_tmpl = 'consul-template-init.erb'
-  end
-
-  template init_file do
-    source init_tmpl
-    mode 0755
-    variables(
-      command: command,
-      options: options,
-      loglevel: node['consul_template']['log_level'],
-      service_user: consul_template_user,
-      service_group: consul_template_group
-    )
-    notifies :restart, 'service[consul-template]', :immediately
-  end
-
-  service 'consul-template' do
-    provider Chef::Provider::Service::Upstart if is_upstart
-    supports status: true, restart: true, reload: true
-    action [:enable, :start]
-    subscribes :restart, "libarchive_file[#{ConsulTemplateHelpers.install_file(node)}]", :delayed
-  end
-
-when 'runit'
-  runit_service 'consul-template' do
-    supports status: true, restart: true, reload: true
-    action [:enable, :start]
-    log true
-    options(
-      command: command,
-      options: options
-    )
-    env 'CONSUL_TEMPLATE_LOG' => node['consul_template']['log_level']
-    subscribes :restart, "libarchive_file[#{ConsulTemplateHelpers.install_file(node)}]", :delayed
-  end
-
-when 'systemd'
-  template '/etc/systemd/system/consul-template.service' do
-    source 'consul-template-systemd.erb'
-    mode 0755
-    variables(
-      command: command,
-      options: options
-    )
-    notifies :restart, 'service[consul-template]', :immediately
-  end
-
-  service 'consul-template' do
-    supports status: true, restart: true, reload: true
-    action [:enable, :start]
-    subscribes :restart, "libarchive_file[#{ConsulTemplateHelpers.install_file(node)}]", :delayed
-  end
-
+# Create service
+poise_service 'consul-template' do
+  command "#{cmd} #{opt}"
 end

--- a/spec/fixtures/cookbooks/consul-template-spec/recipes/consul_template_config.rb
+++ b/spec/fixtures/cookbooks/consul-template-spec/recipes/consul_template_config.rb
@@ -22,5 +22,5 @@ consul_template_config 'test' do
     command: 'touch /tmp/consul-template-command-test',
     perms: 777
   }]
-  notifies :restart, 'service[consul-template]'
+  notifies :restart, 'poise_service[consul-template]'
 end

--- a/spec/recipes/service_spec.rb
+++ b/spec/recipes/service_spec.rb
@@ -12,27 +12,17 @@ describe 'consul-template::service' do
   end
 
   it 'should enable the consul-template service' do
-    expect(chef_run).to enable_service('consul-template')
-  end
-
-  it 'should start the consul-template service' do
-    expect(chef_run).to start_service('consul-template')
+    expect(chef_run).to enable_poise_service('consul-template')
   end
 
   context 'when using init' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.3').converge(described_recipe)
     end
-    it 'should create the consul-template init script' do
-      expect(chef_run).to create_template('/etc/init.d/consul-template')
-    end
 
     it 'should not create the consul-template service user (using root)' do
-      expect(chef_run).to_not create_user('root')
-    end
-
-    it 'should not create the consul-template service group (using root)' do
-      expect(chef_run).to_not create_group('root')
+      expect(chef_run).to_not create_poise_service_user('root')
+        .with(group: 'root')
     end
   end
 
@@ -40,16 +30,9 @@ describe 'consul-template::service' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe)
     end
-    it 'should create the consul-template upstart script' do
-      expect(chef_run).to create_template('/etc/init/consul-template.conf')
-    end
-
     it 'should create the consul-template service user' do
-      expect(chef_run).to create_user('consul-template')
-    end
-
-    it 'should create the consul-template service group' do
-      expect(chef_run).to create_group('consul-template')
+      expect(chef_run).to create_poise_service_user('consul-template')
+        .with(group: 'consul-template')
     end
   end
 
@@ -61,23 +44,8 @@ describe 'consul-template::service' do
     end
 
     it 'should create the consul-template service user' do
-      expect(chef_run).to create_user('consul-template')
-    end
-
-    it 'should create the consul-template service group' do
-      expect(chef_run).to create_group('consul-template')
-    end
-
-    it 'should create the consul-template log directory' do
-      expect(chef_run).to create_directory('/var/log/consul-template')
-    end
-
-    it 'should enable the consul-template service' do
-      expect(chef_run).to enable_runit_service('consul-template')
-    end
-
-    it 'should start the consul-template service' do
-      expect(chef_run).to start_runit_service('consul-template')
+      expect(chef_run).to create_poise_service_user('consul-template')
+        .with(group: 'consul-template')
     end
   end
 
@@ -89,23 +57,8 @@ describe 'consul-template::service' do
     end
 
     it 'should create the consul-template service user' do
-      expect(chef_run).to create_user('consul-template')
-    end
-
-    it 'should create the consul-template service group' do
-      expect(chef_run).to create_group('consul-template')
-    end
-
-    it 'should create the consul-template service config' do
-      expect(chef_run).to create_template('/etc/systemd/system/consul-template.service')
-    end
-
-    it 'should enable the consul-template service' do
-      expect(chef_run).to enable_service('consul-template')
-    end
-
-    it 'should start the consul-template service' do
-      expect(chef_run).to start_service('consul-template')
+      expect(chef_run).to create_poise_service_user('consul-template')
+        .with(group: 'consul-template')
     end
   end
 end


### PR DESCRIPTION
Hi,
Since in many cases cookbook relies on the manual platform/initstyle definition, it might be a good idea to switch to poise_service, which can perform platform/initstyle resolution and create appropriate service files.