### PR TITLE
Fix convergence failure for init systems

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -31,18 +31,16 @@ end
 
 # Create service user
 user consul_template_user do
-  not_if { consul_template_user == 'root' }
   home '/dev/null'
   shell '/bin/false'
   comment 'consul-template service user'
-end
+end unless consul_template_user == 'root'
 
 # Create service group
 group consul_template_group do
-  not_if { consul_template_group == 'root' }
   members consul_template_user
   append true
-end
+end unless consul_template_group == 'root'
 
 # Create service directories
 consul_template_directories.each do |dirname|


### PR DESCRIPTION
Ran into the following issue:
```
STDERR: usermod: user root is currently used by process 1
---- End output of ["usermod", "-c", "consul-template service user", "-s", "/bin/false", "-d", "/dev/null", "root"] ----
Ran ["usermod", "-c", "consul-template service user", "-s", "/bin/false", "-d", "/dev/null", "root"] returned 8
```