### PR TITLE
 Use `match` instead of `match?` for matching arch

### DIFF
--- a/libraries/consul-template_helpers.rb
+++ b/libraries/consul-template_helpers.rb
@@ -22,7 +22,7 @@ class Chef::Recipe::ConsulTemplateHelpers
     private
 
     def install_arch(machine_arch)
-      machine_arch.match?(/x86_64/) ? 'amd64' : '386'
+      machine_arch.match(/x86_64/) ? 'amd64' : '386'
     end
 
     # returns windows friendly version of the provided path,
@@ -41,7 +41,7 @@ class Chef::Recipe::ConsulTemplateHelpers
 
     def program_files
       join_path('C:', 'Program Files') +
-        (node['kernel']['machine'].match?(/x86_64/) ? '' : ' x(86)')
+        (node['kernel']['machine'].match(/x86_64/) ? '' : ' x(86)')
     end
 
     def config_prefix_path


### PR DESCRIPTION
```
2.3.1 :004 > 'x86_64'.match?(/x86_64/) ? 'amd64' : '386'
NoMethodError: undefined method `match?' for "x86_64":String
Did you mean?  match
	from (irb):4
	from /Users/donatas/.rvm/rubies/ruby-2.3.1/bin/irb:11:in `<main>'
```