### PR TITLE
Point out footgun introduced in 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ BREAKING CHANGES:
 - Removes installing from source. Will probably return at a later date.
 - Removes supervisor support.
   ([GH-70](https://github.com/adamkrone/chef-consul-template/issues/70))
+- If you previously relied on setting `['consul_template']['config']['consul']` to point to the Consul server, this will be overridden to `localhost:8500`. Use `default['consul_template']['vault_addr']` from now on.
 
 IMPROVEMENTS:
 


### PR DESCRIPTION
0.13.0 supplies the address of the Consul server on the command line in a new attribute, which overrides the config file. If you previously used the config file to point to a non-localhost consul server, it will be changed upon upgrade.