### PR TITLE
Fixed typo in mode

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -27,7 +27,7 @@ action :create do
     unless node['platform'] == 'windows'
       user consul_template_user
       group consul_template_group
-      mode 0o755
+      mode 0755
     end
     recursive true
     action :create


### PR DESCRIPTION
Looking at previous tags, this was correct: https://github.com/adamkrone/chef-consul-template/blob/v0.11.0/providers/config.rb#L29

So assuming this was not intentional.